### PR TITLE
Use holiday API to show upcoming holidays

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,8 +30,6 @@ Style/ClassAndModuleChildren:
   Enabled: false
 Style/NumericLiterals:
   Enabled: false
-Layout/IndentHash:
-  Enabled: false
 Layout/FirstArrayElementIndentation:
   Enabled: false
 Layout/FirstHashElementIndentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,7 @@ Style/ClassAndModuleChildren:
   Enabled: false
 Style/NumericLiterals:
   Enabled: false
+Layout/FirstArrayElementIndentation:
+  Enabled: false
+Layout/FirstHashElementIndentation:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,8 @@ Style/ClassAndModuleChildren:
   Enabled: false
 Style/NumericLiterals:
   Enabled: false
+Layout/IndentHash:
+  Enabled: false
 Layout/FirstArrayElementIndentation:
   Enabled: false
 Layout/FirstHashElementIndentation:

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem 'simplecov', require: false
   gem 'launchy'
   gem 'factory_bot_rails'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.9)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     diff-lcs (1.4.4)
     docile (1.4.0)
@@ -105,6 +107,7 @@ GEM
     ffi (1.15.1-x86-mingw32)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (1.0.1)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
@@ -295,6 +298,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.13.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.4)
       websocket-extensions (>= 0.1.0)
     websocket-driver (0.7.4-java)
@@ -338,6 +345,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/app/poros/github_contributors.rb
+++ b/app/poros/github_contributors.rb
@@ -2,16 +2,24 @@ class GithubContributors
   def self.contributors_info
     github_contributor_data = GithubService.contributors_info
     if github_contributor_data.is_a? Array
-      github_contributor_data.each_with_object({}) do |contributor, hash|
-        if [26_797_256, 78_388_882, 5_446_926, 78_574_189].include?(contributor[:id])
-          hash[contributor[:id]] =
-            { name: contributor[:login], contributions: contributor[:contributions] }
-        end
-      end
+      only_team_data(github_contributor_data)
     else
-      [['error',
-        { name: 'Unavailable: API rate limit exceeded.',
-          contributions: 'Unavailable: API rate limit exceeded.' }]]
+      error_message
     end
+  end
+
+  def self.only_team_data(data)
+    data.each_with_object({}) do |contributor, hash|
+      if [26_797_256, 78_388_882, 5_446_926, 78_574_189].include?(contributor[:id])
+        hash[contributor[:id]] =
+          { name: contributor[:login], contributions: contributor[:contributions] }
+      end
+    end
+  end
+
+  def self.error_message
+    [['error',
+      { name: 'Unavailable: API rate limit exceeded.',
+        contributions: 'Unavailable: API rate limit exceeded.' }]]
   end
 end

--- a/app/poros/github_pull_requests.rb
+++ b/app/poros/github_pull_requests.rb
@@ -1,6 +1,6 @@
 class GithubPullRequests
   def self.merged_pulls
-    possible_merged = GithubService.closed_pulls
+    possible_merged = GithubService.pull_request_info
     if possible_merged.is_a? Array
       possible_merged.count do |pr|
         !pr[:merged_at].nil?

--- a/app/poros/nager_holiday.rb
+++ b/app/poros/nager_holiday.rb
@@ -4,8 +4,6 @@ class NagerHoliday
     delete_columbus(next_3)
   end
 
-  private
-
   def self.delete_columbus(holidays)
     holidays.each do |holiday|
       holiday[:localName] = "Indigenous Peoples' Day" if holiday[:localName] == 'Columbus Day'

--- a/app/poros/nager_holiday.rb
+++ b/app/poros/nager_holiday.rb
@@ -1,0 +1,15 @@
+class NagerHoliday
+  def self.next_3_holidays
+    next_3 = NagerService.holiday_info[0..2]
+    delete_columbus(next_3)
+  end
+
+  private
+
+  def self.delete_columbus(holidays)
+    holidays.each do |holiday|
+      holiday[:localName] = "Indigenous Peoples' Day" if holiday[:localName] == 'Columbus Day'
+    end
+    holidays
+  end
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -13,7 +13,7 @@ class GithubService
     JSON.parse(body, symbolize_names: true)
   end
 
-  def self.closed_pulls
+  def self.pull_request_info
     response = Faraday.get 'https://api.github.com/repos/mkrumholz/little-shop-of-rails/pulls?state=closed'
 
     body = response.body

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,20 +1,20 @@
 class GithubService
   def self.repo_info
-    response = Faraday.get 'https://api.github.com/repos/LawrenceWhalen/little-esty-shop'
+    response = Faraday.get 'https://api.github.com/repos/mkrumholz/little-shop-of-rails'
 
     body = response.body
     JSON.parse(body, symbolize_names: true)
   end
 
   def self.contributors_info
-    response = Faraday.get 'https://api.github.com/repos/LawrenceWhalen/little-esty-shop/contributors'
+    response = Faraday.get 'https://api.github.com/repos/mkrumholz/little-shop-of-rails/contributors'
 
     body = response.body
     JSON.parse(body, symbolize_names: true)
   end
 
   def self.closed_pulls
-    response = Faraday.get 'https://api.github.com/repos/LawrenceWhalen/little-esty-shop/pulls?state=closed'
+    response = Faraday.get 'https://api.github.com/repos/mkrumholz/little-shop-of-rails/pulls?state=closed'
 
     body = response.body
     JSON.parse(body, symbolize_names: true)

--- a/app/services/nager_service.rb
+++ b/app/services/nager_service.rb
@@ -1,0 +1,8 @@
+class NagerService
+  def self.holiday_info
+    response = Faraday.get 'https://date.nager.at/api/v2/NextPublicHolidays/US'
+      
+    body = response.body
+    JSON.parse(body, symbolize_names: true)
+  end
+end

--- a/app/services/nager_service.rb
+++ b/app/services/nager_service.rb
@@ -1,7 +1,7 @@
 class NagerService
   def self.holiday_info
     response = Faraday.get 'https://date.nager.at/api/v2/NextPublicHolidays/US'
-      
+
     body = response.body
     JSON.parse(body, symbolize_names: true)
   end

--- a/app/views/merchants/discounts/index.html.erb
+++ b/app/views/merchants/discounts/index.html.erb
@@ -7,6 +7,7 @@
   <th> Discount Name </th>
   <th> Percentage Off </th>
   <th> Quantity Threshold </th>
+  <th> Options </th>
   <% @discounts.each do |discount| %>
     <tr id="discount-<%= discount.id %>">
       <td><%= link_to "#{discount.name}", "/merchants/#{@merchant.id}/discounts/#{discount.id}" %></td>
@@ -20,9 +21,9 @@
 <%= button_to 'New discount', new_merchant_discount_path(@merchant.id), method: :get, local: true %>
 
 <section id='holidays'>
-  <h2>Upcoming Holidays</h2>
-
+  <h3>Upcoming Holidays</h3>
   <% NagerHoliday.next_3_holidays.each do |holiday| %>
-    <p><%= holiday[:localName] %>, Date Observed: <%= Date.parse(holiday[:date]).strftime('%A, %B %d, %Y') %></p>
+    <h4><%= holiday[:localName] %></h4>
+    <p>Observed: <%= Date.parse(holiday[:date]).strftime('%A, %B %d, %Y') %></p>
   <% end %>
 </section>

--- a/app/views/merchants/discounts/index.html.erb
+++ b/app/views/merchants/discounts/index.html.erb
@@ -18,3 +18,11 @@
 </table><br/>
 
 <%= button_to 'New discount', new_merchant_discount_path(@merchant.id), method: :get, local: true %>
+
+<section id='holidays'>
+  <h2>Upcoming Holidays</h2>
+
+  <% NagerHoliday.next_3_holidays.each do |holiday| %>
+    <p><%= holiday[:localName] %>, Date Observed: <%= Date.parse(holiday[:date]).strftime('%A, %B %d, %Y') %></p>
+  <% end %>
+</section>

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe 'index.html.erb' do
     before :each do
       allow(GithubService).to receive(:contributors_info).and_return([
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
                                                                      ])
       allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                                 ])
       allow(GithubService).to receive(:repo_info).and_return({
                                                                name: 'little-esty-shop'
@@ -44,12 +44,12 @@ RSpec.describe 'index.html.erb' do
     before :each do
       allow(GithubService).to receive(:contributors_info).and_return([
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
                                                                      ])
       allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                                 ])
       allow(GithubService).to receive(:repo_info).and_return({
                                                                name: 'little-esty-shop'
@@ -110,12 +110,12 @@ RSpec.describe 'index.html.erb' do
     before :each do
       allow(GithubService).to receive(:contributors_info).and_return([
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
                                                                      ])
       allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                                 ])
       allow(GithubService).to receive(:repo_info).and_return({
                                                                name: 'little-esty-shop'

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'index.html.erb' do
       expect(page).to have_content('Monday, January 25, 2021')
       expect(page).to have_content('Saturday, January 25, 2020')
     end
-    
+
     it 'displays the invoices in order created from oldest to newest' do
       expect(@invoice_4.id.to_s).to appear_before(@invoice_6.id.to_s)
       expect(@invoice_6.id.to_s).to appear_before(@invoice_3.id.to_s)

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'index.html.erb' do
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
                                                                        { id: 78388882, name: 'Sa', contributions: 80 }
                                                                      ])
-      allow(GithubService).to receive(:closed_pulls).and_return([
+      allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: nil }
@@ -46,7 +46,7 @@ RSpec.describe 'index.html.erb' do
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
                                                                        { id: 78388882, name: 'Sa', contributions: 80 }
                                                                      ])
-      allow(GithubService).to receive(:closed_pulls).and_return([
+      allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: nil }
@@ -112,7 +112,7 @@ RSpec.describe 'index.html.erb' do
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
                                                                        { id: 78388882, name: 'Sa', contributions: 80 }
                                                                      ])
-      allow(GithubService).to receive(:closed_pulls).and_return([
+      allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -2,20 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'index.html.erb' do
   describe 'visit' do
-    before :each do
-      allow(GithubService).to receive(:contributors_info).and_return([
-                                                                       { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                     ])
-      allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                  { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                                ])
-      allow(GithubService).to receive(:repo_info).and_return({
-                                                               name: 'little-esty-shop'
-                                                             })
-    end
     it 'displays a dashboard' do
       visit '/admin'
 
@@ -23,6 +9,7 @@ RSpec.describe 'index.html.erb' do
         expect(page).to have_content('Admin Dashboard')
       end
     end
+
     it 'has links to the admin merchants index' do
       visit '/admin'
 
@@ -31,6 +18,7 @@ RSpec.describe 'index.html.erb' do
 
       expect(page).to have_current_path('/admin/merchants')
     end
+
     it 'has links to the admin invoices index' do
       visit '/admin'
 
@@ -40,20 +28,9 @@ RSpec.describe 'index.html.erb' do
       expect(page).to have_current_path('/admin/invoices')
     end
   end
+
   describe 'Top 5 Customers' do
     before :each do
-      allow(GithubService).to receive(:contributors_info).and_return([
-                                                                       { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                     ])
-      allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                  { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                                ])
-      allow(GithubService).to receive(:repo_info).and_return({
-                                                               name: 'little-esty-shop'
-                                                             })
       @merchant_1 = Merchant.create!(name: "Ralph's Monkey Hut")
       @customer_1 = Customer.create!(first_name: 'Madi', last_name: 'Johnson')
       @customer_2 = Customer.create!(first_name: 'Emmy', last_name: 'Lost')
@@ -84,6 +61,7 @@ RSpec.describe 'index.html.erb' do
       @invoice_3.transactions.create!(result: 1, credit_card_number: '534', credit_card_expiration_date: 'null')
       visit '/admin'
     end
+
     it 'shows the 5 customers with the most successful transactions' do
       expect(page).to have_content("#{@customer_1.first_name} #{@customer_1.last_name}")
       expect(page).to have_content("#{@customer_3.first_name} #{@customer_3.last_name}")
@@ -92,12 +70,14 @@ RSpec.describe 'index.html.erb' do
       expect(page).to have_content("#{@customer_6.first_name} #{@customer_6.last_name}")
       expect(page).to_not have_content("#{@customer_2.first_name} #{@customer_2.last_name}")
     end
+
     it 'orders them by completed transactions, last name' do
       expect(@customer_4.first_name).to appear_before(@customer_6.first_name)
       expect(@customer_6.first_name).to appear_before(@customer_5.first_name)
       expect(@customer_5.first_name).to appear_before(@customer_1.first_name)
       expect(@customer_1.first_name).to appear_before(@customer_3.first_name)
     end
+
     it 'lists the number of completed transactions' do
       expect(page).to have_content('5 transactions')
       expect(page).to have_content('4 transactions')
@@ -106,20 +86,9 @@ RSpec.describe 'index.html.erb' do
       expect(page).to have_content('1 transactions')
     end
   end
+
   describe 'Incomplete Invoices' do
     before :each do
-      allow(GithubService).to receive(:contributors_info).and_return([
-                                                                       { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                     ])
-      allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                  { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                                ])
-      allow(GithubService).to receive(:repo_info).and_return({
-                                                               name: 'little-esty-shop'
-                                                             })
       @merchant_1 = Merchant.create!(name: "Ralph's Monkey Hut")
       @customer_1 = Customer.create!(first_name: 'Madi', last_name: 'Johnson')
       @customer_2 = Customer.create!(first_name: 'Emmy', last_name: 'Lost')
@@ -144,6 +113,7 @@ RSpec.describe 'index.html.erb' do
       InvoiceItem.create!(quantity: 1, unit_price: 550, status: 0, item: @item_1, invoice: @invoice_6)
       visit '/admin'
     end
+
     it 'displays a list of all invoices with unshipped items' do
       expect(page).to have_content('Incomplete Invoices')
       expect(page).to have_content(@invoice_1.id)
@@ -153,6 +123,7 @@ RSpec.describe 'index.html.erb' do
       expect(page).to have_content(@invoice_6.id)
       expect(page).to_not have_content(@invoice_5.id)
     end
+
     it 'links the ids to their admin show page' do
       expect(page).to have_link("Invoice #{@invoice_1.id}")
       expect(page).to have_link("Invoice #{@invoice_2.id}")
@@ -172,6 +143,7 @@ RSpec.describe 'index.html.erb' do
       expect(page).to have_content('Monday, January 25, 2021')
       expect(page).to have_content('Saturday, January 25, 2020')
     end
+    
     it 'displays the invoices in order created from oldest to newest' do
       expect(@invoice_4.id.to_s).to appear_before(@invoice_6.id.to_s)
       expect(@invoice_6.id.to_s).to appear_before(@invoice_3.id.to_s)

--- a/spec/features/admin/invoices/edit_spec.rb
+++ b/spec/features/admin/invoices/edit_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'Admin Invoice Edit' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/admin/invoices/edit_spec.rb
+++ b/spec/features/admin/invoices/edit_spec.rb
@@ -2,19 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Admin Invoice Edit' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
-
     @customer_1 = Customer.create!(first_name: 'Madi', last_name: 'Johnson')
     @invoice_1 = @customer_1.invoices.create!(status: 1, created_at: '2001-01-01')
 

--- a/spec/features/admin/invoices/edit_spec.rb
+++ b/spec/features/admin/invoices/edit_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Admin Invoice Edit' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -2,18 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'admin/invoices/show.html.erb' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
     @customer_1 = Customer.create!(first_name: 'Madi', last_name: 'Johnson')
     @invoice_1 = @customer_1.invoices.create!(status: 1, created_at: '2001-01-01')
     @merchant_1 = Merchant.create!(name: "Ralph's Monkey Hut")
@@ -26,17 +14,20 @@ RSpec.describe 'admin/invoices/show.html.erb' do
 
     visit "/admin/invoices/#{@invoice_1.id}"
   end
+
   describe 'visit' do
     it 'displays invoice data' do
       expect(page).to have_content(@invoice_1.id)
       expect(page).to have_content(@invoice_1.status)
       expect(page).to have_content('Monday, January 01, 2001')
     end
+
     it 'displays invoices customer name' do
       expect(page).to have_content(@customer_1.first_name)
       expect(page).to have_content(@customer_1.last_name)
     end
   end
+
   describe 'items on invoice' do
     it 'displays all of the items on the invoice' do
       expect(page).to have_content(@item_1.name)
@@ -50,6 +41,7 @@ RSpec.describe 'admin/invoices/show.html.erb' do
       expect(page).to have_content('$0.16')
     end
   end
+  
   describe 'total revenue' do
     it 'shows the total revenue the invoice will generate' do
       expect(page).to have_content('Total Revenue: $620.16')

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'admin/invoices/show.html.erb' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'admin/invoices/show.html.erb' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'admin/invoices/show.html.erb' do
       expect(page).to have_content('$0.16')
     end
   end
-  
+
   describe 'total revenue' do
     it 'shows the total revenue the invoice will generate' do
       expect(page).to have_content('Total Revenue: $620.16')

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'Admin Merchant Edit' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -2,18 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Admin Merchant Edit' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
     @signs = Merchant.create!(name: "Sal's Signs", status: true)
 
     visit("/admin/merchants/#{@signs.id}/edit")

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Admin Merchant Edit' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Admin Merchants Index' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -2,18 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Admin Merchants Index' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
     @signs = Merchant.create!(name: "Sal's Signs", status: true)
     @tees = Merchant.create!(name: 'T-shirts by Terry', status: true)
     @amphs = Merchant.create!(name: 'All About Amphibians', status: false)

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'Admin Merchants Index' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'New merchant page' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -2,18 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'New merchant page' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
     visit '/admin/merchants/new'
   end
 

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'New merchant page' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'Admin Merchant Show' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Admin Merchant Show' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -2,18 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Admin Merchant Show' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
     @signs = Merchant.create!(name: "Sal's Signs", status: true)
 
     visit("/admin/merchants/#{@signs.id}")

--- a/spec/features/admin/welcome_spec.rb
+++ b/spec/features/admin/welcome_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Welcome page' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/admin/welcome_spec.rb
+++ b/spec/features/admin/welcome_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'Welcome page' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/admin/welcome_spec.rb
+++ b/spec/features/admin/welcome_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Welcome page' do
 
     visit '/'
   end
-  
+
   describe 'visit' do
     it 'has a button to the admin index' do
       expect(page).to have_link('Admin Index')

--- a/spec/features/admin/welcome_spec.rb
+++ b/spec/features/admin/welcome_spec.rb
@@ -2,25 +2,13 @@ require 'rails_helper'
 
 RSpec.describe 'Welcome page' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
-
     @merchant_1 = Merchant.create!(name: 'Tims my time', status: false)
     @merchant_2 = Merchant.create!(name: 'Future Fun', status: false)
     @merchant_3 = Merchant.create!(name: 'Dozen a Dime', status: false)
 
     visit '/'
   end
+  
   describe 'visit' do
     it 'has a button to the admin index' do
       expect(page).to have_link('Admin Index')

--- a/spec/features/layouts/application_spec.rb
+++ b/spec/features/layouts/application_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'footer' do
                                                                      { id: 26797256, login: 'Molly', contributions: 7 },
                                                                      { id: 78388882, login: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: '0101010011', name: 'Molly', merged_at: 7 },
                                                                 { id: '01011230011', name: 'Sa', merged_at: 80 },
                                                                 { id: '01011230011', name: 'Sa', merged_at: nil }

--- a/spec/features/layouts/application_spec.rb
+++ b/spec/features/layouts/application_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'footer' do
   before :each do
     visit '/admin'
   end
-  
+
   it 'displays repo name' do
     within 'footer' do
       expect(page).to have_content('little-shop-of-rails')

--- a/spec/features/layouts/application_spec.rb
+++ b/spec/features/layouts/application_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'footer' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, login: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, login: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, login: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: '0101010011', name: 'Molly', merged_at: 7 },
-                                                                { id: '01011230011', name: 'Sa', merged_at: 80 },
-                                                                { id: '01011230011', name: 'Sa', merged_at: nil }
+                                                                { id: '01011230011', name: 'Sid', merged_at: 80 },
+                                                                { id: '01011230011', name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/layouts/application_spec.rb
+++ b/spec/features/layouts/application_spec.rb
@@ -2,29 +2,18 @@ require 'rails_helper'
 
 RSpec.describe 'footer' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, login: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, login: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: '0101010011', name: 'Molly', merged_at: 7 },
-                                                                { id: '01011230011', name: 'Sid', merged_at: 80 },
-                                                                { id: '01011230011', name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
     visit '/admin'
   end
+  
   it 'displays repo name' do
     within 'footer' do
-      expect(page).to have_content('little-esty-shop')
+      expect(page).to have_content('little-shop-of-rails')
     end
   end
   it 'displays contributor names and commits' do
     expect(page).to have_content('Contributor: Molly')
     expect(page).to have_content('Commits: 7')
-    expect(page).to have_content('Contributor: Sa')
+    expect(page).to have_content('Contributor: Sid')
     expect(page).to have_content('Commits: 80')
   end
   it 'displays number of merged pulls' do

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -1,21 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe 'Dashboard' do
+  before :each do
+    allow(NagerHoliday).to receive(:next_3_holidays).and_return([
+      {date: '2021-07-05', localName: 'Independence Day'}, 
+      {date: '2021-09-06', localName: 'Labor Day'}, 
+      {date: '2021-10-11', localName: 'Columbus Day'},
+      {date: '2021-11-11', localName: 'Veterans Day'}
+    ])
+  end
+
   describe 'dashboard' do
     it 'can see the name of the merchants' do
-      allow(GithubService).to receive(:contributors_info).and_return([
-                                                                       { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                     ])
-      allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                  { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                                ])
-      allow(GithubService).to receive(:repo_info).and_return({
-                                                               name: 'little-esty-shop'
-                                                             })
-
       merchant = FactoryBot.create(:merchant)
 
       visit "/merchants/#{merchant.id}/dashboard"
@@ -24,19 +20,6 @@ RSpec.describe 'Dashboard' do
     end
 
     it 'can see links to the merchant items, invoice, and discount indexes' do
-      allow(GithubService).to receive(:contributors_info).and_return([
-                                                                       { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                     ])
-      allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                  { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                                ])
-      allow(GithubService).to receive(:repo_info).and_return({
-                                                               name: 'little-esty-shop'
-                                                             })
-
       merchant = FactoryBot.create(:merchant)
 
       visit "/merchants/#{merchant.id}/dashboard"
@@ -59,19 +42,6 @@ RSpec.describe 'Dashboard' do
     end
 
     it 'can see the name of the top 5 customers' do
-      allow(GithubService).to receive(:contributors_info).and_return([
-                                                                       { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                     ])
-      allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                  { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                                ])
-      allow(GithubService).to receive(:repo_info).and_return({
-                                                               name: 'little-esty-shop'
-                                                             })
-
       merchant = FactoryBot.create(:merchant)
       customer_2 = Customer.create!(first_name: 'Evan', last_name: 'East')
       customer_3 = Customer.create!(first_name: 'Yasha', last_name: 'West')
@@ -131,19 +101,6 @@ RSpec.describe 'Dashboard' do
     end
 
     it 'can see the items ready to ship' do
-      allow(GithubService).to receive(:contributors_info).and_return([
-                                                                       { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                     ])
-      allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                  { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                                ])
-      allow(GithubService).to receive(:repo_info).and_return({
-                                                               name: 'little-esty-shop'
-                                                             })
-
       merchant = FactoryBot.create(:merchant)
       customer_2 = Customer.create!(first_name: 'Evan', last_name: 'East')
       customer_3 = Customer.create!(first_name: 'Yasha', last_name: 'West')
@@ -233,19 +190,6 @@ RSpec.describe 'Dashboard' do
     end
 
     it 'can see the invoices sorted by least recent' do
-      allow(GithubService).to receive(:contributors_info).and_return([
-                                                                       { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                     ])
-      allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                  { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                                ])
-      allow(GithubService).to receive(:repo_info).and_return({
-                                                               name: 'little-esty-shop'
-                                                             })
-
       merchant = FactoryBot.create(:merchant)
       customer_2 = Customer.create!(first_name: 'Evan', last_name: 'East')
       customer_3 = Customer.create!(first_name: 'Yasha', last_name: 'West')

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Dashboard' do
   before :each do
     allow(NagerHoliday).to receive(:next_3_holidays).and_return([
-      {date: '2021-07-05', localName: 'Independence Day'}, 
-      {date: '2021-09-06', localName: 'Labor Day'}, 
-      {date: '2021-10-11', localName: 'Columbus Day'},
-      {date: '2021-11-11', localName: 'Veterans Day'}
+      { date: '2021-07-05', localName: 'Independence Day' },
+      { date: '2021-09-06', localName: 'Labor Day' },
+      { date: '2021-10-11', localName: 'Columbus Day' },
+      { date: '2021-11-11', localName: 'Veterans Day' }
     ])
   end
 

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe 'Dashboard' do
     it 'can see the name of the merchants' do
       allow(GithubService).to receive(:contributors_info).and_return([
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
                                                                      ])
       allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                                 ])
       allow(GithubService).to receive(:repo_info).and_return({
                                                                name: 'little-esty-shop'
@@ -26,12 +26,12 @@ RSpec.describe 'Dashboard' do
     it 'can see links to the merchant items, invoice, and discount indexes' do
       allow(GithubService).to receive(:contributors_info).and_return([
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
                                                                      ])
       allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                                 ])
       allow(GithubService).to receive(:repo_info).and_return({
                                                                name: 'little-esty-shop'
@@ -61,12 +61,12 @@ RSpec.describe 'Dashboard' do
     it 'can see the name of the top 5 customers' do
       allow(GithubService).to receive(:contributors_info).and_return([
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
                                                                      ])
       allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                                 ])
       allow(GithubService).to receive(:repo_info).and_return({
                                                                name: 'little-esty-shop'
@@ -133,12 +133,12 @@ RSpec.describe 'Dashboard' do
     it 'can see the items ready to ship' do
       allow(GithubService).to receive(:contributors_info).and_return([
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
                                                                      ])
       allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                                 ])
       allow(GithubService).to receive(:repo_info).and_return({
                                                                name: 'little-esty-shop'
@@ -235,12 +235,12 @@ RSpec.describe 'Dashboard' do
     it 'can see the invoices sorted by least recent' do
       allow(GithubService).to receive(:contributors_info).and_return([
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
                                                                      ])
       allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                                 ])
       allow(GithubService).to receive(:repo_info).and_return({
                                                                name: 'little-esty-shop'

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Dashboard' do
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
                                                                        { id: 78388882, name: 'Sa', contributions: 80 }
                                                                      ])
-      allow(GithubService).to receive(:closed_pulls).and_return([
+      allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: nil }
@@ -28,7 +28,7 @@ RSpec.describe 'Dashboard' do
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
                                                                        { id: 78388882, name: 'Sa', contributions: 80 }
                                                                      ])
-      allow(GithubService).to receive(:closed_pulls).and_return([
+      allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: nil }
@@ -63,7 +63,7 @@ RSpec.describe 'Dashboard' do
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
                                                                        { id: 78388882, name: 'Sa', contributions: 80 }
                                                                      ])
-      allow(GithubService).to receive(:closed_pulls).and_return([
+      allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: nil }
@@ -135,7 +135,7 @@ RSpec.describe 'Dashboard' do
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
                                                                        { id: 78388882, name: 'Sa', contributions: 80 }
                                                                      ])
-      allow(GithubService).to receive(:closed_pulls).and_return([
+      allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: nil }
@@ -237,7 +237,7 @@ RSpec.describe 'Dashboard' do
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
                                                                        { id: 78388882, name: 'Sa', contributions: 80 }
                                                                      ])
-      allow(GithubService).to receive(:closed_pulls).and_return([
+      allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/merchants/discounts/create_spec.rb
+++ b/spec/features/merchants/discounts/create_spec.rb
@@ -2,6 +2,13 @@ require 'rails_helper'
 
 RSpec.describe 'new discount page' do
   before :each do
+    allow(NagerHoliday).to receive(:next_3_holidays).and_return([
+      {date: '2021-07-05', localName: 'Independence Day'}, 
+      {date: '2021-09-06', localName: 'Labor Day'}, 
+      {date: '2021-10-11', localName: 'Columbus Day'},
+      {date: '2021-11-11', localName: 'Veterans Day'}
+    ])
+    
     @merchant_1 = FactoryBot.create(:merchant)
     @merchant_2 = FactoryBot.create(:merchant)
 

--- a/spec/features/merchants/discounts/create_spec.rb
+++ b/spec/features/merchants/discounts/create_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe 'new discount page' do
   before :each do
     allow(NagerHoliday).to receive(:next_3_holidays).and_return([
-      {date: '2021-07-05', localName: 'Independence Day'}, 
-      {date: '2021-09-06', localName: 'Labor Day'}, 
-      {date: '2021-10-11', localName: 'Columbus Day'},
-      {date: '2021-11-11', localName: 'Veterans Day'}
+      { date: '2021-07-05', localName: 'Independence Day' },
+      { date: '2021-09-06', localName: 'Labor Day' },
+      { date: '2021-10-11', localName: 'Columbus Day' },
+      { date: '2021-11-11', localName: 'Veterans Day' }
     ])
-    
+
     @merchant_1 = FactoryBot.create(:merchant)
     @merchant_2 = FactoryBot.create(:merchant)
 

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -2,20 +2,20 @@ require 'rails_helper'
 
 RSpec.describe 'merchant discount index' do
   before :each do
-    WebMock.stub_request(:get, /date.nager.at/).
-          with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
-          to_return(status: 200, body: [
-            {date: '2021-07-05', localName: 'Independence Day'}, 
-            {date: '2021-09-06', localName: 'Labor Day'}, 
-            {date: '2021-10-11', localName: 'Columbus Day'},
-            {date: '2021-11-11', localName: 'Veterans Day'}
+    WebMock.stub_request(:get, /date.nager.at/)
+           .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Faraday v1.4.2' })
+           .to_return(status: 200, body: [
+            { date: '2021-07-05', localName: 'Independence Day' },
+            { date: '2021-09-06', localName: 'Labor Day' },
+            { date: '2021-10-11', localName: 'Columbus Day' },
+            { date: '2021-11-11', localName: 'Veterans Day' }
             ].to_json,
             headers: {})
-                    
+
     uri = URI('https://date.nager.at/api/v2/NextPublicHolidays/US')
     # allow(NagerHoliday).to receive(:next_3_holidays).and_return([
-    #   {date: '2021-07-05', localName: 'Independence Day'}, 
-    #   {date: '2021-09-06', localName: 'Labor Day'}, 
+    #   {date: '2021-07-05', localName: 'Independence Day'},
+    #   {date: '2021-09-06', localName: 'Labor Day'},
     #   {date: '2021-10-11', localName: 'Columbus Day'},
     #   {date: '2021-11-11', localName: 'Veterans Day'}
     # ])
@@ -77,7 +77,7 @@ RSpec.describe 'merchant discount index' do
   end
 
   it 'displays the next 3 public holidays' do
-    within "section#holidays" do 
+    within 'section#holidays' do
       expect(page).to have_content 'Upcoming Holidays'
       expect(page).to have_content 'Independence Day'
       expect(page).to have_content 'Observed: Monday, July 05, 2021'
@@ -85,7 +85,7 @@ RSpec.describe 'merchant discount index' do
       expect(page).to have_content 'Observed: Monday, September 06, 2021'
       expect(page).to have_content "Indigenous Peoples' Day"
       expect(page).to have_content 'Observed: Monday, October 11, 2021'
-      expect(page).to_not have_content "Veterans Day"
+      expect(page).to_not have_content 'Veterans Day'
     end
   end
 end

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -92,11 +92,11 @@ RSpec.describe 'merchant discount index' do
     within "section#holidays" do 
       expect(page).to have_content 'Upcoming Holidays'
       expect(page).to have_content 'Independence Day'
-      expect(page).to have_content 'Date Observed: Monday, July 05, 2021'
+      expect(page).to have_content 'Observed: Monday, July 05, 2021'
       expect(page).to have_content 'Labor Day'
-      expect(page).to have_content 'Date Observed: Monday, September 06, 2021'
+      expect(page).to have_content 'Observed: Monday, September 06, 2021'
       expect(page).to have_content "Indigenous Peoples' Day"
-      expect(page).to have_content 'Date Observed: Monday, October 11, 2021'
+      expect(page).to have_content 'Observed: Monday, October 11, 2021'
       expect(page).to_not have_content "Veterans Day"
     end
   end

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -14,6 +14,23 @@ RSpec.describe 'merchant discount index' do
     allow(GithubService).to receive(:repo_info).and_return({
       name: 'little-shop-of-rails'
     })
+    WebMock.stub_request(:get, /date.nager.at/).
+          with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
+          to_return(status: 200, body: [
+            {date: '2021-07-05', localName: 'Independence Day'}, 
+            {date: '2021-09-06', localName: 'Labor Day'}, 
+            {date: '2021-10-11', localName: 'Columbus Day'},
+            {date: '2021-11-11', localName: 'Veterans Day'}
+            ].to_json,
+            headers: {})
+                    
+    uri = URI('https://date.nager.at/api/v2/NextPublicHolidays/US')
+    # allow(NagerService).to receive(:next_3_holidays).and_return([
+    #   {date: '2021-07-05', localName: 'Independence Day'}, 
+    #   {date: '2021-09-06', localName: 'Labor Day'}, 
+    #   {date: '2021-10-11', localName: 'Columbus Day'},
+    #   {date: '2021-11-11', localName: 'Veterans Day'}
+    # ])
 
     @merchant_1 = FactoryBot.create(:merchant)
     @merchant_2 = FactoryBot.create(:merchant)
@@ -72,33 +89,15 @@ RSpec.describe 'merchant discount index' do
   end
 
   it 'displays the next 3 public holidays' do
-    WebMock.stub_request(:get, /date.nager.at/).
-          with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
-          to_return(status: 200, body: [
-            {date: '2021-07-05', localName: 'Independence Day'}, 
-            {date: '2021-09-06', localName: 'Labor Day'}, 
-            {date: '2021-10-11', localName: 'Columbus Day'},
-            {date: '2021-11-11', localName: 'Veterans Day'}
-            ].to_json,
-            headers: {})
-                    
-    uri = URI('https://date.nager.at/api/v2/NextPublicHolidays/US')
-    # allow(NagerService).to receive(:next_3_holidays).and_return([
-    #   {date: '2021-07-05', localName: 'Independence Day'}, 
-    #   {date: '2021-09-06', localName: 'Labor Day'}, 
-    #   {date: '2021-10-11', localName: 'Columbus Day'},
-    #   {date: '2021-11-11', localName: 'Veterans Day'}
-    # ])
-
     within "section#holidays" do 
       expect(page).to have_content 'Upcoming Holidays'
-      expect(page).to have content 'Independence Day'
-      expect(page).to have content 'Date: Sunday, July 4th, 2021'
-      expect(page).to have content 'Labor Day'
-      expect(page).to have content 'Date: Monday, September 6th, 2021'
-      expect(page).to have content "Indigenous Peoples' Day"
-      expect(page).to have content 'Date: Monday, October 11th, 2021'
-      expect(page).to_not have content "Veterans Day"
+      expect(page).to have_content 'Independence Day'
+      expect(page).to have_content 'Date Observed: Monday, July 05, 2021'
+      expect(page).to have_content 'Labor Day'
+      expect(page).to have_content 'Date Observed: Monday, September 06, 2021'
+      expect(page).to have_content "Indigenous Peoples' Day"
+      expect(page).to have_content 'Date Observed: Monday, October 11, 2021'
+      expect(page).to_not have_content "Veterans Day"
     end
   end
 end

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'merchant discount index' do
             headers: {})
                     
     uri = URI('https://date.nager.at/api/v2/NextPublicHolidays/US')
-    # allow(NagerService).to receive(:next_3_holidays).and_return([
+    # allow(NagerHoliday).to receive(:next_3_holidays).and_return([
     #   {date: '2021-07-05', localName: 'Independence Day'}, 
     #   {date: '2021-09-06', localName: 'Labor Day'}, 
     #   {date: '2021-10-11', localName: 'Columbus Day'},

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -2,18 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'merchant discount index' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-      { id: 26797256, name: 'Molly', contributions: 7 },
-      { id: 78388882, name: 'Sid', contributions: 80 }
-    ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-      { id: 0o101010011, name: 'Molly', merged_at: '2021-03-07' },
-      { id: 0o1011230011, name: 'Sid', merged_at: '2021-03-08' },
-      { id: 0o1011230011, name: 'Sid', merged_at: nil }
-    ])
-    allow(GithubService).to receive(:repo_info).and_return({
-      name: 'little-shop-of-rails'
-    })
     WebMock.stub_request(:get, /date.nager.at/).
           with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
           to_return(status: 200, body: [

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -16,13 +16,8 @@ RSpec.describe 'Merchant Invoices Index' do
                                                                name: 'little-esty-shop'
                                                              })
     end
+
     it 'can see all of the invoices that include at least one of my merchants items' do
-      # Merchant Invoices Index
-      # As a merchant,
-      # When I visit my merchant's invoices index (/merchants/merchant_id/invoices)
-      # Then I see all of the invoices that include at least one of my merchant's items
-      # And for each invoice I see its id
-      # And each id links to the merchant invoice show page
       merchant = Merchant.create!(name: 'Schroeder-Jerde')
       merchant_2 = Merchant.create!(name: 'James Bond')
       customer_2 = Customer.create!(first_name: 'Evan', last_name: 'East')

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Merchant Invoices Index' do
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
                                                                        { id: 78388882, name: 'Sa', contributions: 80 }
                                                                      ])
-      allow(GithubService).to receive(:closed_pulls).and_return([
+      allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe 'Merchant Invoices Index' do
     before :each do
       allow(GithubService).to receive(:contributors_info).and_return([
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
                                                                      ])
       allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                                 ])
       allow(GithubService).to receive(:repo_info).and_return({
                                                                name: 'little-esty-shop'

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -2,21 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Merchant Invoices Index' do
   describe 'index page' do
-    before :each do
-      allow(GithubService).to receive(:contributors_info).and_return([
-                                                                       { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                     ])
-      allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                  { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                                ])
-      allow(GithubService).to receive(:repo_info).and_return({
-                                                               name: 'little-esty-shop'
-                                                             })
-    end
-
     it 'can see all of the invoices that include at least one of my merchants items' do
       merchant = Merchant.create!(name: 'Schroeder-Jerde')
       merchant_2 = Merchant.create!(name: 'James Bond')

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -2,21 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Merchant Invoices Show Page' do
   describe 'show page' do
-    before :each do
-      allow(GithubService).to receive(:contributors_info).and_return([
-                                                                       { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                     ])
-      allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                  { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                                ])
-      allow(GithubService).to receive(:repo_info).and_return({
-                                                               name: 'little-esty-shop'
-                                                             })
-    end
-
     it 'can see all of that merchants invoice info' do
       merchant = Merchant.create!(name: 'Schroeder-Jerde')
       customer_2 = Customer.create!(first_name: 'Evan', last_name: 'East')

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe 'Merchant Invoices Show Page' do
     before :each do
       allow(GithubService).to receive(:contributors_info).and_return([
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                       { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                       { id: 78388882, name: 'Sid', contributions: 80 }
                                                                      ])
       allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                  { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                  { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                                 ])
       allow(GithubService).to receive(:repo_info).and_return({
                                                                name: 'little-esty-shop'

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Merchant Invoices Show Page' do
                                                                        { id: 26797256, name: 'Molly', contributions: 7 },
                                                                        { id: 78388882, name: 'Sa', contributions: 80 }
                                                                      ])
-      allow(GithubService).to receive(:closed_pulls).and_return([
+      allow(GithubService).to receive(:pull_request_info).and_return([
                                                                   { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                   { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/merchants/items/create_spec.rb
+++ b/spec/features/merchants/items/create_spec.rb
@@ -2,19 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Merchant item create page' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
-
     @merchant = FactoryBot.create(:merchant)
 
     visit "/merchants/#{@merchant.id}/items/new"

--- a/spec/features/merchants/items/create_spec.rb
+++ b/spec/features/merchants/items/create_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'Merchant item create page' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/merchants/items/create_spec.rb
+++ b/spec/features/merchants/items/create_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Merchant item create page' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -2,19 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'The merchant item show page' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
-
     @merchant = FactoryBot.create(:merchant_with_items)
     @item_1 = @merchant.items.first
 

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'The merchant item show page' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'The merchant item show page' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -2,18 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'The merchant items index' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
     @merchant = FactoryBot.create(:merchant_with_items)
     @customer = FactoryBot.create(:customer)
 

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'The merchant items index' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'The merchant items index' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -2,19 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'The merchant item show page' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
-
     @merchant = Merchant.create!(name: 'Little Shop of Horrors')
     @item_1 = @merchant.items.create!(name: 'Audrey II', description: 'Large, man-eating plant', unit_price: '100000000')
 

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'The merchant item show page' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'The merchant item show page' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/partials/admin_nav_spec.rb
+++ b/spec/features/partials/admin_nav_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'admin header nav' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/features/partials/admin_nav_spec.rb
+++ b/spec/features/partials/admin_nav_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'admin header nav' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/partials/admin_nav_spec.rb
+++ b/spec/features/partials/admin_nav_spec.rb
@@ -2,19 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'admin header nav' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
-
     visit '/admin'
   end
 

--- a/spec/features/partials/merchant_nav_spec.rb
+++ b/spec/features/partials/merchant_nav_spec.rb
@@ -2,19 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'merchant header nav' do
   before :each do
-    allow(GithubService).to receive(:contributors_info).and_return([
-                                                                     { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
-                                                                   ])
-    allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
-                                                              ])
-    allow(GithubService).to receive(:repo_info).and_return({
-                                                             name: 'little-esty-shop'
-                                                           })
-
     @merchant = FactoryBot.create(:merchant)
 
     visit "/merchants/#{@merchant.id}/dashboard"

--- a/spec/features/partials/merchant_nav_spec.rb
+++ b/spec/features/partials/merchant_nav_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'merchant header nav' do
   before :each do
     allow(GithubService).to receive(:contributors_info).and_return([
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
-                                                                     { id: 78388882, name: 'Sa', contributions: 80 }
+                                                                     { id: 78388882, name: 'Sid', contributions: 80 }
                                                                    ])
     allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: 80 },
-                                                                { id: 0o1011230011, name: 'Sa', merged_at: nil }
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: 80 },
+                                                                { id: 0o1011230011, name: 'Sid', merged_at: nil }
                                                               ])
     allow(GithubService).to receive(:repo_info).and_return({
                                                              name: 'little-esty-shop'

--- a/spec/features/partials/merchant_nav_spec.rb
+++ b/spec/features/partials/merchant_nav_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'merchant header nav' do
                                                                      { id: 26797256, name: 'Molly', contributions: 7 },
                                                                      { id: 78388882, name: 'Sa', contributions: 80 }
                                                                    ])
-    allow(GithubService).to receive(:closed_pulls).and_return([
+    allow(GithubService).to receive(:pull_request_info).and_return([
                                                                 { id: 0o101010011, name: 'Molly', merged_at: 7 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: 80 },
                                                                 { id: 0o1011230011, name: 'Sa', merged_at: nil }

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Customer do
       @invoice_1.transactions.create!(result: 1, credit_card_number: '534', credit_card_expiration_date: 'null')
       @invoice_3.transactions.create!(result: 1, credit_card_number: '534', credit_card_expiration_date: 'null')
     end
-    
+
     describe '#top_five_completed_transactions' do
       it 'returns the 5 customers with the most completed transactions' do
         actual = Customer.top_five_completed_transactions

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe Item do
         expect(@item_1.price_to_dollars).to eq 1000000.0
       end
     end
+    
     describe '#highest_revenue_date' do
       it 'returns the date on which the most revenue was earned for the item' do
         expect(@item_1.highest_revenue_date).to eq Date.parse('2021-03-01')

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Item do
         expect(@item_1.price_to_dollars).to eq 1000000.0
       end
     end
-    
+
     describe '#highest_revenue_date' do
       it 'returns the date on which the most revenue was earned for the item' do
         expect(@item_1.highest_revenue_date).to eq Date.parse('2021-03-01')

--- a/spec/poros/github_contributors_spec.rb
+++ b/spec/poros/github_contributors_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe GithubContributors do
                                                                          },
                                                                          {
                                                                            id: 5_446_926,
-                                                                           name: 'Sa,',
+                                                                           name: 'Sid',
                                                                            contributions: 80
                                                                          }
                                                                        ])

--- a/spec/poros/github_contributors_spec.rb
+++ b/spec/poros/github_contributors_spec.rb
@@ -5,17 +5,9 @@ RSpec.describe GithubContributors do
     describe '#contributor_info' do
       it 'returns a hash with key of id and value of contributor info' do
         allow(GithubService).to receive(:contributors_info).and_return([
-                                                                         {
-                                                                           id: 26_797_256,
-                                                                           name: 'Molly',
-                                                                           contributions: 7
-                                                                         },
-                                                                         {
-                                                                           id: 5_446_926,
-                                                                           name: 'Sid',
-                                                                           contributions: 80
-                                                                         }
-                                                                       ])
+          {id: 26_797_256, login: 'Molly', contributions: 7},
+          {id: 5_446_926, login: 'Sid', contributions: 80}
+          ])
 
         expect(GithubContributors.contributors_info.keys.first).to eq(26_797_256)
         expect(GithubContributors.contributors_info.values.first.class).to eq(Hash)

--- a/spec/poros/github_contributors_spec.rb
+++ b/spec/poros/github_contributors_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe GithubContributors do
     describe '#contributor_info' do
       it 'returns a hash with key of id and value of contributor info' do
         allow(GithubService).to receive(:contributors_info).and_return([
-          {id: 26_797_256, login: 'Molly', contributions: 7},
-          {id: 5_446_926, login: 'Sid', contributions: 80}
-          ])
+          { id: 26_797_256, login: 'Molly', contributions: 7 },
+          { id: 5_446_926, login: 'Sid', contributions: 80 }
+        ])
 
         expect(GithubContributors.contributors_info.keys.first).to eq(26_797_256)
         expect(GithubContributors.contributors_info.values.first.class).to eq(Hash)

--- a/spec/poros/github_pull_requests_spec.rb
+++ b/spec/poros/github_pull_requests_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe GithubPullRequests do
   describe 'class methods' do
     describe '.merged_pulls' do
       it 'returns a count of merged pull requests' do
-        allow(GithubService).to receive(:closed_pulls).and_return([
+        allow(GithubService).to receive(:pull_request_info).and_return([
                                                                     {
                                                                       id: 0o101010011,
                                                                       name: 'Molly',
@@ -26,7 +26,7 @@ RSpec.describe GithubPullRequests do
       end
 
       it 'returns an error if the api count is exceeded' do
-        allow(GithubService).to receive(:closed_pulls).and_return(
+        allow(GithubService).to receive(:pull_request_info).and_return(
           {
             :message => "API rate limit exceeded for 98.38.149.214. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
             :documentation_url => 'https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting'

--- a/spec/poros/github_pull_requests_spec.rb
+++ b/spec/poros/github_pull_requests_spec.rb
@@ -5,22 +5,10 @@ RSpec.describe GithubPullRequests do
     describe '.merged_pulls' do
       it 'returns a count of merged pull requests' do
         allow(GithubService).to receive(:pull_request_info).and_return([
-                                                                    {
-                                                                      id: 0o101010011,
-                                                                      name: 'Molly',
-                                                                      merged_at: 7
-                                                                    },
-                                                                    {
-                                                                      id: 0o1011230011,
-                                                                      name: 'Sa,',
-                                                                      merged_at: 80
-                                                                    },
-                                                                    {
-                                                                      id: 0o1011230011,
-                                                                      name: 'Sa,',
-                                                                      merged_at: nil
-                                                                    }
-                                                                  ])
+          {id: 0101010011, merged_at: 7},
+          {id: 01011230011, merged_at: 80},
+          {id: 01011230011, merged_at: nil}
+        ])
 
         expect(GithubPullRequests.merged_pulls).to eq(2)
       end

--- a/spec/poros/github_pull_requests_spec.rb
+++ b/spec/poros/github_pull_requests_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe GithubPullRequests do
     describe '.merged_pulls' do
       it 'returns a count of merged pull requests' do
         allow(GithubService).to receive(:pull_request_info).and_return([
-          {id: 0101010011, merged_at: 7},
-          {id: 01011230011, merged_at: 80},
-          {id: 01011230011, merged_at: nil}
+          { id: 0o101010011, merged_at: 7 },
+          { id: 0o1011230011, merged_at: 80 },
+          { id: 0o1011230011, merged_at: nil }
         ])
 
         expect(GithubPullRequests.merged_pulls).to eq(2)

--- a/spec/poros/github_repo_spec.rb
+++ b/spec/poros/github_repo_spec.rb
@@ -4,15 +4,15 @@ RSpec.describe GithubRepo do
   describe '.name' do
     it 'returns the name of the repo' do
       allow(GithubService).to receive(:repo_info).and_return({
-        name: 'little-esty-shop'
+        name: 'little-shop-of-rails'
       })
 
-      expect(GithubRepo.name_info).to eq('little-esty-shop')
+      expect(GithubRepo.name_info).to eq('little-shop-of-rails')
     end
     it 'returns an error if the api limit is exceeded' do
       allow(GithubService).to receive(:repo_info).and_return({
         message: 'error',
-        name: 'little-esty-shop'
+        name: 'little-shop-of-rails'
       })
 
       expect(GithubRepo.name_info).to eq('Unavailable: API rate limit exceeded.')

--- a/spec/poros/github_repo_spec.rb
+++ b/spec/poros/github_repo_spec.rb
@@ -4,16 +4,16 @@ RSpec.describe GithubRepo do
   describe '.name' do
     it 'returns the name of the repo' do
       allow(GithubService).to receive(:repo_info).and_return({
-                                                               name: 'little-esty-shop'
-                                                             })
+        name: 'little-esty-shop'
+      })
 
       expect(GithubRepo.name_info).to eq('little-esty-shop')
     end
     it 'returns an error if the api limit is exceeded' do
       allow(GithubService).to receive(:repo_info).and_return({
-                                                               message: 'error',
-                                                               name: 'little-esty-shop'
-                                                             })
+        message: 'error',
+        name: 'little-esty-shop'
+      })
 
       expect(GithubRepo.name_info).to eq('Unavailable: API rate limit exceeded.')
     end

--- a/spec/poros/nager_holiday_spec.rb
+++ b/spec/poros/nager_holiday_spec.rb
@@ -3,26 +3,23 @@ require 'rails_helper'
 RSpec.describe NagerHoliday do
   describe '.next_3_holidays' do
     it 'returns the name and date of the next 3 US public holidays' do
-      allow(NagerService).to receive(:holiday_info).and_return({
+      allow(NagerService).to receive(:holiday_info).and_return([{
         date: '2021-07-05',
         localName: 'Independence Day'
-      },
-      {
+      }, {
         date: '2021-09-06',
         localName: 'Labor Day'
-      }, 
-      {
+      }, {
         date: '2021-10-11',
         localName: 'Columbus Day'
-      },
-      {
+      },{
         date: '2021-11-11',
         localName: 'Veterans Day'
-      })
+      }])
 
-      holiday_1 = {date: '2021-07-05', 'Independence Day'}
-      holiday_2 = {date: '2021-09-06', 'Labor Day'}
-      holiday_3 = {date: '2021-10-11', name: "Indigenous Peoples' Day"}
+      holiday_1 = {date: '2021-07-05', localName: 'Independence Day'}
+      holiday_2 = {date: '2021-09-06', localName: 'Labor Day'}
+      holiday_3 = {date: '2021-10-11', localName: "Indigenous Peoples' Day"}
 
       expect(NagerHoliday.next_3_holidays).to eq([holiday_1, holiday_2, holiday_3])
     end

--- a/spec/poros/nager_holiday_spec.rb
+++ b/spec/poros/nager_holiday_spec.rb
@@ -4,15 +4,15 @@ RSpec.describe NagerHoliday do
   describe '.next_3_holidays' do
     it 'returns the name and date of the next 3 US public holidays' do
       allow(NagerService).to receive(:holiday_info).and_return([
-        {date: '2021-07-05',localName: 'Independence Day'}, 
-        {date: '2021-09-06', localName: 'Labor Day'}, 
-        {date: '2021-10-11', localName: 'Columbus Day'},
-        {date: '2021-11-11', localName: 'Veterans Day'}
+        { date: '2021-07-05', localName: 'Independence Day' },
+        { date: '2021-09-06', localName: 'Labor Day' },
+        { date: '2021-10-11', localName: 'Columbus Day' },
+        { date: '2021-11-11', localName: 'Veterans Day' }
       ])
 
-      holiday_1 = {date: '2021-07-05', localName: 'Independence Day'}
-      holiday_2 = {date: '2021-09-06', localName: 'Labor Day'}
-      holiday_3 = {date: '2021-10-11', localName: "Indigenous Peoples' Day"}
+      holiday_1 = { date: '2021-07-05', localName: 'Independence Day' }
+      holiday_2 = { date: '2021-09-06', localName: 'Labor Day' }
+      holiday_3 = { date: '2021-10-11', localName: "Indigenous Peoples' Day" }
 
       expect(NagerHoliday.next_3_holidays).to eq([holiday_1, holiday_2, holiday_3])
     end

--- a/spec/poros/nager_holiday_spec.rb
+++ b/spec/poros/nager_holiday_spec.rb
@@ -3,19 +3,12 @@ require 'rails_helper'
 RSpec.describe NagerHoliday do
   describe '.next_3_holidays' do
     it 'returns the name and date of the next 3 US public holidays' do
-      allow(NagerService).to receive(:holiday_info).and_return([{
-        date: '2021-07-05',
-        localName: 'Independence Day'
-      }, {
-        date: '2021-09-06',
-        localName: 'Labor Day'
-      }, {
-        date: '2021-10-11',
-        localName: 'Columbus Day'
-      },{
-        date: '2021-11-11',
-        localName: 'Veterans Day'
-      }])
+      allow(NagerService).to receive(:holiday_info).and_return([
+        {date: '2021-07-05',localName: 'Independence Day'}, 
+        {date: '2021-09-06', localName: 'Labor Day'}, 
+        {date: '2021-10-11', localName: 'Columbus Day'},
+        {date: '2021-11-11', localName: 'Veterans Day'}
+      ])
 
       holiday_1 = {date: '2021-07-05', localName: 'Independence Day'}
       holiday_2 = {date: '2021-09-06', localName: 'Labor Day'}

--- a/spec/poros/nager_holiday_spec.rb
+++ b/spec/poros/nager_holiday_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe NagerHoliday do
+  describe '.next_3_holidays' do
+    it 'returns the name and date of the next 3 US public holidays' do
+      allow(NagerService).to receive(:holiday_info).and_return({
+        date: '2021-07-05',
+        localName: 'Independence Day'
+      },
+      {
+        date: '2021-09-06',
+        localName: 'Labor Day'
+      }, 
+      {
+        date: '2021-10-11',
+        localName: 'Columbus Day'
+      },
+      {
+        date: '2021-11-11',
+        localName: 'Veterans Day'
+      })
+
+      holiday_1 = {date: '2021-07-05', 'Independence Day'}
+      holiday_2 = {date: '2021-09-06', 'Labor Day'}
+      holiday_3 = {date: '2021-10-11', name: "Indigenous Peoples' Day"}
+
+      expect(NagerHoliday.next_3_holidays).to eq([holiday_1, holiday_2, holiday_3])
+    end
+  end
+end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe GithubService do
   describe 'class methods', :service do
     describe '#repo_info' do
       it 'queries repo info on GitHub' do
-        WebMock.stub_request(:get, /api.github.com/).
-          with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
-          to_return(status: 200, body: {name: 'little-shop-of-rails'}.to_json, headers: {})
+        WebMock.stub_request(:get, /api.github.com/)
+               .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Faraday v1.4.2' })
+               .to_return(status: 200, body: { name: 'little-shop-of-rails' }.to_json, headers: {})
 
         uri = URI('https://api.github.com/repos/mkrumholz/little-shop-of-rails')
 
@@ -19,14 +19,14 @@ RSpec.describe GithubService do
 
     describe '#contributors_info' do
       it 'queries contributor info on GitHub' do
-        WebMock.stub_request(:get, /api.github.com/).
-          with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
-          to_return(status: 200, body: {login: 'mkrumholz', contributions: 177}.to_json, headers: {})
+        WebMock.stub_request(:get, /api.github.com/)
+               .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Faraday v1.4.2' })
+               .to_return(status: 200, body: { login: 'mkrumholz', contributions: 177 }.to_json, headers: {})
 
         uri = URI('https://api.github.com/repos/mkrumholz/little-shop-of-rails/contributors')
 
         response = GithubService.contributors_info
-        
+
         expect(response[:login]).to eq('mkrumholz')
         expect(response[:contributions]).to eq(177)
       end
@@ -34,9 +34,9 @@ RSpec.describe GithubService do
 
     describe '#pull_request_info' do
       it 'queries pull request info on GitHub' do
-        WebMock.stub_request(:get, /api.github.com/).
-          with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
-          to_return(status: 200, body: {id: 668978499, merged_at: '2021-06-13T02:31:59Z'}.to_json, headers: {})
+        WebMock.stub_request(:get, /api.github.com/)
+               .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Faraday v1.4.2' })
+               .to_return(status: 200, body: { id: 668978499, merged_at: '2021-06-13T02:31:59Z' }.to_json, headers: {})
 
         uri = URI('https://api.github.com/repos/mkrumholz/little-shop-of-rails/pulls?state=closed')
 

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe GithubService do
-  describe 'class methods' do
+  describe 'class methods', :service do
     describe '#repo_info' do
       it 'queries repo info on GitHub' do
         WebMock.stub_request(:get, /api.github.com/).
@@ -26,7 +26,7 @@ RSpec.describe GithubService do
         uri = URI('https://api.github.com/repos/mkrumholz/little-shop-of-rails/contributors')
 
         response = GithubService.contributors_info
-
+        
         expect(response[:login]).to eq('mkrumholz')
         expect(response[:contributions]).to eq(177)
       end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -3,26 +3,46 @@ require 'rails_helper'
 RSpec.describe GithubService do
   describe 'class methods' do
     describe '#repo_info' do
-      xit 'returns a collection of data for the repo' do
-        actual = GithubService.repo_info
+      it 'queries repo info on GitHub' do
+        WebMock.stub_request(:get, /api.github.com/).
+          with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
+          to_return(status: 200, body: {name: 'little-shop-of-rails'}.to_json, headers: {})
 
-        expect(actual[:name]).to eq('little-esty-shop')
+        uri = URI('https://api.github.com/repos/mkrumholz/little-shop-of-rails')
+
+        response = GithubService.repo_info
+
+        expect(response).to be_an_instance_of(Hash)
+        expect(response[:name]).to eq('little-shop-of-rails')
       end
     end
 
     describe '#contributors_info' do
-      xit 'returns all contributors info' do
-        actual = GithubService.contributors_info
+      it 'queries contributor info on GitHub' do
+        WebMock.stub_request(:get, /api.github.com/).
+          with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
+          to_return(status: 200, body: {login: 'mkrumholz', contributions: 177}.to_json, headers: {})
 
-        expect(actual[0][:login]).to eq('mkrumholz')
+        uri = URI('https://api.github.com/repos/mkrumholz/little-shop-of-rails/contributors')
+
+        response = GithubService.contributors_info
+
+        expect(response[:login]).to eq('mkrumholz')
+        expect(response[:contributions]).to eq(177)
       end
     end
 
-    describe '#closed_pulls' do
-      xit 'returns all closed pulls from the repo' do
-        actual = GithubService.closed_pulls
-        expect(actual[0]).to have_key(:id)
-        expect(actual[0]).to have_key(:merged_at)
+    describe '#pull_request_info' do
+      it 'queries pull request info on GitHub' do
+        WebMock.stub_request(:get, /api.github.com/).
+          with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
+          to_return(status: 200, body: {id: 668978499, merged_at: '2021-06-13T02:31:59Z'}.to_json, headers: {})
+
+        uri = URI('https://api.github.com/repos/mkrumholz/little-shop-of-rails/pulls?state=closed')
+
+        response = GithubService.pull_request_info
+        expect(response[:id]).to eq 668978499
+        expect(response[:merged_at]).to eq '2021-06-13T02:31:59Z'
       end
     end
   end

--- a/spec/services/nager_service_spec.rb
+++ b/spec/services/nager_service_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe GithubService do
+  describe 'class methods' do
+    describe '.holiday_info' do
+      it 'queries public holiday info for the US on Nager.at' do
+        WebMock.stub_request(:get, /date.nager.at/).
+          with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
+          to_return(status: 200, body: [{date: "2021-07-05", localName: 'Independence Day'}, 
+                                        {date: "2021-09-06", localName: "Labor Day"}].to_json,
+                    headers: {})
+                    
+        uri = URI('https://date.nager.at/api/v2/NextPublicHolidays/US')
+
+        response = NagerService.holiday_info
+
+        expect(response[0][:date]).to eq '2021-07-05'
+        expect(response[0][:localName]).to eq 'Independence Day'
+        expect(response[1][:date]).to eq '2021-09-06'
+        expect(response[1][:localName]).to eq 'Labor Day'
+      end
+    end
+  end 
+end

--- a/spec/services/nager_service_spec.rb
+++ b/spec/services/nager_service_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe GithubService do
   describe '.holiday_info', :service do
     it 'queries public holiday info for the US on Nager.at' do
-      WebMock.stub_request(:get, /date.nager.at/).
-        with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
-        to_return(status: 200, body: [{date: "2021-07-05", localName: 'Independence Day'}, 
-                                      {date: "2021-09-06", localName: "Labor Day"}].to_json,
-                  headers: {})
-                  
+      WebMock.stub_request(:get, /date.nager.at/)
+             .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Faraday v1.4.2' })
+             .to_return(status: 200, body: [{ date: '2021-07-05', localName: 'Independence Day' },
+                                            { date: '2021-09-06', localName: 'Labor Day' }].to_json,
+                        headers: {})
+
       uri = URI('https://date.nager.at/api/v2/NextPublicHolidays/US')
 
       response = NagerService.holiday_info
@@ -18,5 +18,5 @@ RSpec.describe GithubService do
       expect(response[1][:date]).to eq '2021-09-06'
       expect(response[1][:localName]).to eq 'Labor Day'
     end
-  end 
+  end
 end

--- a/spec/services/nager_service_spec.rb
+++ b/spec/services/nager_service_spec.rb
@@ -1,24 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe GithubService do
-  describe 'class methods' do
-    describe '.holiday_info' do
-      it 'queries public holiday info for the US on Nager.at' do
-        WebMock.stub_request(:get, /date.nager.at/).
-          with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
-          to_return(status: 200, body: [{date: "2021-07-05", localName: 'Independence Day'}, 
-                                        {date: "2021-09-06", localName: "Labor Day"}].to_json,
-                    headers: {})
-                    
-        uri = URI('https://date.nager.at/api/v2/NextPublicHolidays/US')
+  describe '.holiday_info', :service do
+    it 'queries public holiday info for the US on Nager.at' do
+      WebMock.stub_request(:get, /date.nager.at/).
+        with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Faraday v1.4.2'}).
+        to_return(status: 200, body: [{date: "2021-07-05", localName: 'Independence Day'}, 
+                                      {date: "2021-09-06", localName: "Labor Day"}].to_json,
+                  headers: {})
+                  
+      uri = URI('https://date.nager.at/api/v2/NextPublicHolidays/US')
 
-        response = NagerService.holiday_info
+      response = NagerService.holiday_info
 
-        expect(response[0][:date]).to eq '2021-07-05'
-        expect(response[0][:localName]).to eq 'Independence Day'
-        expect(response[1][:date]).to eq '2021-09-06'
-        expect(response[1][:localName]).to eq 'Labor Day'
-      end
+      expect(response[0][:date]).to eq '2021-07-05'
+      expect(response[0][:localName]).to eq 'Independence Day'
+      expect(response[1][:date]).to eq '2021-09-06'
+      expect(response[1][:localName]).to eq 'Labor Day'
     end
   end 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,20 @@ SimpleCov.start do
   add_filter 'spec/factories'
 end
 RSpec.configure do |config|
+  config.before(:each) do
+    allow(GithubService).to receive(:contributors_info).and_return([
+      { id: 26797256, name: 'Molly', contributions: 7 },
+      { id: 78388882, name: 'Sid', contributions: 80 }
+    ])
+    allow(GithubService).to receive(:pull_request_info).and_return([
+      { id: 0o101010011, name: 'Molly', merged_at: '2021-03-07' },
+      { id: 0o1011230011, name: 'Sid', merged_at: '2021-03-08' },
+      { id: 0o1011230011, name: 'Sid', merged_at: nil }
+    ])
+    allow(GithubService).to receive(:repo_info).and_return({
+      name: 'little-shop-of-rails'
+    })
+   end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,5 +100,5 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
-  WebMock.disable_net_connect!(allow_localhost: true)
 end
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,8 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'capybara/rspec'
 require 'simplecov'
+require 'webmock/rspec'
+
 SimpleCov.start do
   add_filter 'spec/rails_helper.rb'
   add_filter 'modules/dollarable.rb'
@@ -85,7 +87,7 @@ RSpec.configure do |config|
   #   # Print the 10 slowest examples and example groups at the
   #   # end of the spec run, to help surface which specs are running
   #   # particularly slow.
-  #   config.profile_examples = 10
+    config.profile_examples = 10
   #
   #   # Run specs in random order to surface order dependencies. If you find an
   #   # order dependency and want to debug it, you can fix the order by providing
@@ -98,4 +100,5 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+  WebMock.disable_net_connect!(allow_localhost: true)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,21 +24,27 @@ SimpleCov.start do
 end
 RSpec.configure do |config|
   config.before(:each) do |test|
-    allow(GithubService).to receive(:contributors_info).and_return([
-      { id: 26797256, login: 'Molly', contributions: 7 },
-      { id: 78388882, login: 'Sid', contributions: 80 }
-    ]) unless test.metadata[:service]
+    unless test.metadata[:service]
+      allow(GithubService).to receive(:contributors_info).and_return([
+        { id: 26797256, login: 'Molly', contributions: 7 },
+        { id: 78388882, login: 'Sid', contributions: 80 }
+      ])
+    end
 
-    allow(GithubService).to receive(:pull_request_info).and_return([
-      { id: 0o101010011, name: 'Molly', merged_at: '2021-03-07' },
-      { id: 0o1011230011, name: 'Sid', merged_at: '2021-03-08' },
-      { id: 0o1011230011, name: 'Sid', merged_at: nil }
-    ]) unless test.metadata[:service]
+    unless test.metadata[:service]
+      allow(GithubService).to receive(:pull_request_info).and_return([
+        { id: 0o101010011, name: 'Molly', merged_at: '2021-03-07' },
+        { id: 0o1011230011, name: 'Sid', merged_at: '2021-03-08' },
+        { id: 0o1011230011, name: 'Sid', merged_at: nil }
+      ])
+    end
 
-    allow(GithubService).to receive(:repo_info).and_return({
-      name: 'little-shop-of-rails'
-    }) unless test.metadata[:service]
-   end
+    unless test.metadata[:service]
+      allow(GithubService).to receive(:repo_info).and_return({
+        name: 'little-shop-of-rails'
+      })
+    end
+  end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
@@ -103,7 +109,7 @@ RSpec.configure do |config|
   #   # Print the 10 slowest examples and example groups at the
   #   # end of the spec run, to help surface which specs are running
   #   # particularly slow.
-    # config.profile_examples = 10
+  # config.profile_examples = 10
   #
   #   # Run specs in random order to surface order dependencies. If you find an
   #   # order dependency and want to debug it, you can fix the order by providing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,19 +23,21 @@ SimpleCov.start do
   add_filter 'spec/factories'
 end
 RSpec.configure do |config|
-  config.before(:each) do
+  config.before(:each) do |test|
     allow(GithubService).to receive(:contributors_info).and_return([
       { id: 26797256, login: 'Molly', contributions: 7 },
       { id: 78388882, login: 'Sid', contributions: 80 }
-    ])
+    ]) unless test.metadata[:service]
+
     allow(GithubService).to receive(:pull_request_info).and_return([
       { id: 0o101010011, name: 'Molly', merged_at: '2021-03-07' },
       { id: 0o1011230011, name: 'Sid', merged_at: '2021-03-08' },
       { id: 0o1011230011, name: 'Sid', merged_at: nil }
-    ])
+    ]) unless test.metadata[:service]
+
     allow(GithubService).to receive(:repo_info).and_return({
       name: 'little-shop-of-rails'
-    })
+    }) unless test.metadata[:service]
    end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -101,7 +103,7 @@ RSpec.configure do |config|
   #   # Print the 10 slowest examples and example groups at the
   #   # end of the spec run, to help surface which specs are running
   #   # particularly slow.
-    config.profile_examples = 10
+    # config.profile_examples = 10
   #
   #   # Run specs in random order to surface order dependencies. If you find an
   #   # order dependency and want to debug it, you can fix the order by providing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,8 +25,8 @@ end
 RSpec.configure do |config|
   config.before(:each) do
     allow(GithubService).to receive(:contributors_info).and_return([
-      { id: 26797256, name: 'Molly', contributions: 7 },
-      { id: 78388882, name: 'Sid', contributions: 80 }
+      { id: 26797256, login: 'Molly', contributions: 7 },
+      { id: 78388882, login: 'Sid', contributions: 80 }
     ])
     allow(GithubService).to receive(:pull_request_info).and_return([
       { id: 0o101010011, name: 'Molly', merged_at: '2021-03-07' },


### PR DESCRIPTION
## Changes

- Moved before hook for API stubbing to config and created metadata exceptions for service tests (to expose WebMock)
- Updated test formatting and spacing from Little Esty
- Created a service to call the Nager date API for NextPublicHolidays
- Created a PORO that scrubs the holidays and returns only the next 3
- Added upcoming holiday info to the merchant discounts index page

## Special review requests

Check-in about before hook structure/implementation

## Checklist
- [x] Tests written where required
- [x] All tests passing
- [x] SimpleCov at 100%

closes #7 
closes #3 
